### PR TITLE
Added data mask support

### DIFF
--- a/sdram.vhd
+++ b/sdram.vhd
@@ -445,6 +445,24 @@ begin
   sdram_dq <= data_reg((BURST_LENGTH-wait_counter)*SDRAM_DATA_WIDTH-1 downto (BURST_LENGTH-wait_counter-1)*SDRAM_DATA_WIDTH) when state = WRITE else (others => 'Z');
 
   -- set SDRAM data mask
-  sdram_dqmh <= mask_reg(3) when (wait_counter = 0) else mask_reg(1);
-  sdram_dqml <= mask_reg(2) when (wait_counter = 0) else mask_reg(0);
+  --sdram_dqmh <= mask_reg(3) when (wait_counter = 0) else mask_reg(1);
+  --sdram_dqml <= mask_reg(2) when (wait_counter = 0) else mask_reg(0);
+
+
+  process (state, wait_counter)
+  begin
+    if (state = WRITE) then
+      if (wait_counter = 0) then
+        sdram_dqmh <= mask_reg(3);
+        sdram_dqml <= mask_reg(2);
+      else
+        sdram_dqmh <= mask_reg(1);
+        sdram_dqml <= mask_reg(0);
+      end if;
+    else
+      sdram_dqmh <= '0';
+      sdram_dqml <= '0';
+    end if;
+  end process;
+
 end architecture arch;

--- a/sdram.vhd
+++ b/sdram.vhd
@@ -92,6 +92,9 @@ entity sdram is
     -- input data bus
     data : in std_logic_vector(DATA_WIDTH-1 downto 0);
 
+    -- input data mask
+    mask : in std_logic_vector(3 downto 0);
+
     -- When the write enable signal is asserted, a write operation will be performed.
     we : in std_logic;
 
@@ -216,6 +219,7 @@ architecture arch of sdram is
   signal addr_reg : unsigned(SDRAM_COL_WIDTH+SDRAM_ROW_WIDTH+SDRAM_BANK_WIDTH-1 downto 0);
   signal data_reg : std_logic_vector(DATA_WIDTH-1 downto 0);
   signal we_reg   : std_logic;
+  signal mask_reg : std_logic_vector(3 downto 0);
   signal q_reg    : std_logic_vector(DATA_WIDTH-1 downto 0);
 
   -- aliases to decode the address register
@@ -367,6 +371,7 @@ begin
         addr_reg <= shift_left(resize(addr, addr_reg'length), 1);
         data_reg <= data;
         we_reg   <= we;
+        mask_reg <= not mask;
       end if;
     end if;
   end process;
@@ -440,6 +445,6 @@ begin
   sdram_dq <= data_reg((BURST_LENGTH-wait_counter)*SDRAM_DATA_WIDTH-1 downto (BURST_LENGTH-wait_counter-1)*SDRAM_DATA_WIDTH) when state = WRITE else (others => 'Z');
 
   -- set SDRAM data mask
-  sdram_dqmh <= '0';
-  sdram_dqml <= '0';
+  sdram_dqmh <= mask_reg(3) when (wait_counter = 0) else mask_reg(1);
+  sdram_dqml <= mask_reg(2) when (wait_counter = 0) else mask_reg(0);
 end architecture arch;

--- a/sdram.vhd
+++ b/sdram.vhd
@@ -449,7 +449,7 @@ begin
   --sdram_dqml <= mask_reg(2) when (wait_counter = 0) else mask_reg(0);
 
 
-  process (state, wait_counter)
+  process (state, wait_counter, mask_reg)
   begin
     if (state = WRITE) then
       if (wait_counter = 0) then


### PR DESCRIPTION
I have added support for a data mask (byteenable). It was testet on a DE0-nano board with the neorv32 project.
I am not sure if I must add the mask in case of a refresh cycle too.